### PR TITLE
fix: include started_at in /sessions response

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -136,7 +136,8 @@ async def list_sessions():
         "session_id": sid,
         "display_name": bot.display_name,
         "status": bot.status.value,
-        "uptime_seconds": bot.get_uptime()
+        "uptime_seconds": bot.get_uptime(),
+        "started_at": bot.started_at.isoformat() if bot.started_at else None
     } for sid, bot in active_sessions.items()]
 
 


### PR DESCRIPTION
Fixes #20

The `/sessions` endpoint now includes `started_at` as an ISO 8601 datetime string so consumers can calculate uptime correctly.