### PR TITLE
Optional access token to protect endpoints (except /)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,8 @@ AZURE_STORAGE_PUBLIC_ENDPOINT=http://127.0.0.1:410000/devstoreaccount1
 # Called when a recording finishes saving
 # Leave empty to disable webhooks
 WEBHOOK_URL=
+
+# Optional access token protecting all endpoints except "/" (health probe).
+# When set, every request must send `Authorization: Bearer <token>` or
+# `X-API-Key: <token>`. Leave empty to keep the recorder open.
+BOT_ACCESS_TOKEN=

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ TeamsMeetingRecorder can be configured using environment variables. Create a `.e
 | `AZURE_STORAGE_CONTAINER` | `meeting-recordings` | Blob container name |
 | `AZURE_STORAGE_PUBLIC_ENDPOINT` | - | Optional public blob base URL for webhook `file_location` |
 | `WEBHOOK_URL` | - | Webhook URL to notify when recording completes (optional) |
+| `BOT_ACCESS_TOKEN` | - | Optional shared secret protecting all endpoints except `/` (the health probe). When set, every request must send `Authorization: Bearer <token>` or `X-API-Key: <token>` (401 otherwise). Unset = open. |
 
 **Example `.env` file:**
 ```env

--- a/app/config.py
+++ b/app/config.py
@@ -48,6 +48,12 @@ class Settings(BaseSettings):
     # Called when a recording finishes saving (both local and MinIO)
     webhook_url: Optional[str] = None
 
+    # Optional shared secret protecting all endpoints except "/" (the health
+    # probe). Set via env BOT_ACCESS_TOKEN. When set, every request must send
+    # `Authorization: Bearer <token>` or `X-API-Key: <token>` (401 otherwise).
+    # Leave unset to keep the recorder open (no inbound auth).
+    bot_access_token: Optional[str] = None
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,14 @@
 """FastAPI application for Teams Meeting Recorder."""
 
-from fastapi import FastAPI, HTTPException, BackgroundTasks
-from fastapi.responses import FileResponse
+from fastapi import FastAPI, HTTPException, BackgroundTasks, Request
+from fastapi.responses import FileResponse, JSONResponse
 from contextlib import asynccontextmanager
+import hmac
 import uvicorn
 import asyncio
 import logging
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 from app.models import (
     JoinMeetingRequest,
@@ -55,6 +56,36 @@ app = FastAPI(
     description="API for recording Microsoft Teams meetings using a bot",
     lifespan=lifespan
 )
+
+
+# Paths reachable without the access token. "/" is the container health probe.
+_OPEN_PATHS = {"/"}
+
+
+def _extract_token(request: Request) -> Optional[str]:
+    """Pull the bearer token or X-API-Key from the request headers."""
+    auth = request.headers.get("authorization")
+    if auth and auth.lower().startswith("bearer "):
+        return auth[len("bearer "):].strip()
+    api_key = request.headers.get("x-api-key")
+    if api_key:
+        return api_key.strip()
+    return None
+
+
+@app.middleware("http")
+async def access_token_guard(request: Request, call_next):
+    """Optional inbound auth: when BOT_ACCESS_TOKEN is set, every endpoint
+    except the open paths requires it. No-op when the token is unset."""
+    expected = settings.bot_access_token
+    if expected and request.url.path not in _OPEN_PATHS:
+        provided = _extract_token(request)
+        if not provided or not hmac.compare_digest(provided, expected):
+            return JSONResponse(
+                status_code=401,
+                content={"success": False, "error": "Unauthorized"},
+            )
+    return await call_next(request)
 
 
 @app.get("/")


### PR DESCRIPTION
## What
Adds an optional `BOT_ACCESS_TOKEN`. When set, every endpoint **except `/`** (the compose healthcheck target) requires `Authorization: Bearer <token>` or `X-API-Key: <token>` — `401` otherwise. Unset = open (no inbound auth), so existing deployments are unaffected.

## How
- `app/main.py`: `@app.middleware("http")` guard, constant-time compare (`hmac.compare_digest`), `/` kept open for the healthcheck.
- `app/config.py`: `bot_access_token` (env `BOT_ACCESS_TOKEN`).
- README env table + `.env.example` documented.

## Note
When enabled, callers of `/join` etc. must send the token too, or they get 401.