### PR TITLE
Send optional X-Webhook-Secret header on recording webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,10 @@ AZURE_STORAGE_PUBLIC_ENDPOINT=http://127.0.0.1:410000/devstoreaccount1
 # Leave empty to disable webhooks
 WEBHOOK_URL=
 
+# Optional shared secret sent as the X-Webhook-Secret header on webhook POSTs;
+# the receiver verifies it against its own Webhook:Secret. Leave empty to send none.
+WEBHOOK_SECRET=
+
 # Optional access token protecting all endpoints except "/" (health probe).
 # When set, every request must send `Authorization: Bearer <token>` or
 # `X-API-Key: <token>`. Leave empty to keep the recorder open.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ TeamsMeetingRecorder can be configured using environment variables. Create a `.e
 | `AZURE_STORAGE_CONTAINER` | `meeting-recordings` | Blob container name |
 | `AZURE_STORAGE_PUBLIC_ENDPOINT` | - | Optional public blob base URL for webhook `file_location` |
 | `WEBHOOK_URL` | - | Webhook URL to notify when recording completes (optional) |
+| `WEBHOOK_SECRET` | - | Optional shared secret sent as the `X-Webhook-Secret` header on webhook POSTs; the receiver verifies it against its `Webhook:Secret`. Unset = no signature. |
 | `BOT_ACCESS_TOKEN` | - | Optional shared secret protecting all endpoints except `/` (the health probe). When set, every request must send `Authorization: Bearer <token>` or `X-API-Key: <token>` (401 otherwise). Unset = open. |
 
 **Example `.env` file:**

--- a/app/config.py
+++ b/app/config.py
@@ -48,6 +48,11 @@ class Settings(BaseSettings):
     # Called when a recording finishes saving (both local and MinIO)
     webhook_url: Optional[str] = None
 
+    # Optional shared secret sent as the X-Webhook-Secret header on webhook POSTs;
+    # the receiver (Summarly API) verifies it against its Webhook:Secret. Set via
+    # env WEBHOOK_SECRET. Leave unset to send no signature.
+    webhook_secret: Optional[str] = None
+
     # Optional shared secret protecting all endpoints except "/" (the health
     # probe). Set via env BOT_ACCESS_TOKEN. When set, every request must send
     # `Authorization: Bearer <token>` or `X-API-Key: <token>` (401 otherwise).

--- a/app/webhook.py
+++ b/app/webhook.py
@@ -7,6 +7,8 @@ from typing import Optional
 from datetime import datetime
 import aiohttp
 
+from app.config import settings
+
 logger = logging.getLogger(__name__)
 
 
@@ -66,12 +68,16 @@ async def send_webhook(webhook_url: str, payload: WebhookPayload) -> bool:
     try:
         logger.info(f"Sending webhook notification to: {webhook_url}")
 
+        headers = {"Content-Type": "application/json"}
+        if settings.webhook_secret:
+            headers["X-Webhook-Secret"] = settings.webhook_secret
+
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 webhook_url,
                 json=payload.to_dict(),
                 timeout=aiohttp.ClientTimeout(total=30),
-                headers={"Content-Type": "application/json"}
+                headers=headers
             ) as response:
                 if response.status in (200, 201, 202, 204):
                     logger.info(f"Webhook sent successfully (status: {response.status})")


### PR DESCRIPTION
Completes the API-side webhook verification. When `WEBHOOK_SECRET` is set, the bot sends it as the `X-Webhook-Secret` header on the recording webhook POST; the API verifies it against its `Webhook:Secret`. Unset = no header (open, unchanged). Documented in README + .env.example. py_compile clean.
