### PR TITLE
Restyle README, add a recording cap, reap browser children

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,7 +38,7 @@ logs/
 
 # Docker
 Dockerfile
-compose.yaml
+compose.yml
 docker-compose.yml
 .dockerignore
 

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ TEAMS_WAIT_FOR_LOBBY=10
 # Debug mode: save screenshots (set to true to enable)
 
 # Storage backend: 'local', 'minio', or 'azure'
+# Hard cap on a single recording, in minutes. 0 disables it.
+MAX_RECORDING_MINUTES=240
+
 STORAGE_BACKEND=local
 
 # MinIO settings (only required when STORAGE_BACKEND=minio)
@@ -14,11 +17,13 @@ MINIO_BUCKET=recordings
 MINIO_SECURE=true
 
 # Azure Blob settings (only required when STORAGE_BACKEND=azure)
-# Azurite (local): use docker compose -f azurite.compose.yaml up -d
-AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:410000/devstoreaccount1;
+# Azurite (local): use docker compose -f azurite.compose.yml up -d
+# Azurite: 'UseDevelopmentStorage=true' expands to Azurite's built-in dev account.
+# For a real account use the connection string from the Azure portal.
+AZURE_STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true
 AZURE_STORAGE_CONTAINER=meeting-recordings
 # Optional: public base URL included in webhook file_location (HTTP download)
-AZURE_STORAGE_PUBLIC_ENDPOINT=http://127.0.0.1:410000/devstoreaccount1
+AZURE_STORAGE_PUBLIC_ENDPOINT=http://127.0.0.1:41000/devstoreaccount1
 
 # Webhook configuration (optional)
 # Called when a recording finishes saving

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,7 @@ docker-entrypoint.sh text eol=lf
 # Docker files
 Dockerfile text eol=lf
 docker-compose.yml text eol=lf
-compose.yaml text eol=lf
+compose.yml text eol=lf
 
 # Documentation
 *.md text eol=lf

--- a/README.md
+++ b/README.md
@@ -1,75 +1,72 @@
-# <p align="center">TeamsMeetingRecorder</p>
 <p align="center">
-  <img src="./assets/TeamsRecorderTransparent.png" width="200" alt="TeamsMeetingRecorder Logo">
+  <img src="./assets/TeamsRecorderTransparent.png" width="140" alt="TeamsMeetingRecorder logo">
+</p>
+
+<h1 align="center">TeamsMeetingRecorder</h1>
+
+<p align="center">
+  <strong>A bot that joins Microsoft Teams meetings and records the audio.</strong>
 </p>
 
 <p align="center">
-  <strong>A simple bot that automatically joins Microsoft Teams meetings and records audio.</strong>
-</p> 
-
-<p align="center">
-  <a href="https://github.com/PianoNic/TeamsMeetingRecorder"><img src="https://badgetrack.pianonic.ch/badge?tag=teams-meeting-recorder&label=visits&color=5558d9&style=flat" alt="visits"/></a>
-  <a href="https://github.com/PianoNic/TeamsMeetingRecorder/blob/main/LICENSE"><img src="https://img.shields.io/github/license/PianoNic/TeamsMeetingRecorder?color=5558d9"/></a>
-  <a href="https://github.com/PianoNic/TeamsMeetingRecorder/releases"><img src="https://img.shields.io/github/v/release/PianoNic/TeamsMeetingRecorder?include_prereleases&color=5558d9&label=Latest%20Release"/></a>
-  <a href="#-docker--container-registry-usage"><img src="https://img.shields.io/badge/Selfhost-Instructions-5558d9.svg"/></a>
+  <a href="https://github.com/PianoNic/TeamsMeetingRecorder"><img src="https://badgetrack.pianonic.ch/badge?tag=teams-meeting-recorder&label=visits&color=0d1117&style=flat" alt="visits" /></a>
+  <a href="https://github.com/PianoNic/TeamsMeetingRecorder/releases"><img src="https://img.shields.io/github/v/release/PianoNic/TeamsMeetingRecorder?include_prereleases&color=0d1117&label=Latest" alt="Latest release" /></a>
+  <a href="https://github.com/PianoNic/TeamsMeetingRecorder/blob/main/LICENSE"><img src="https://img.shields.io/github/license/PianoNic/TeamsMeetingRecorder?color=0d1117" alt="License" /></a>
+  <a href="#get-started"><img src="https://img.shields.io/badge/Self--Host-Instructions-0d1117.svg" alt="Self-hosting" /></a>
+  <img src="https://img.shields.io/badge/Python-3.12-0d1117.svg" alt="Python 3.12" />
+  <img src="https://img.shields.io/badge/FastAPI-0d1117.svg" alt="FastAPI" />
+  <img src="https://img.shields.io/badge/Playwright-0d1117.svg" alt="Playwright" />
 </p>
 
-> [!IMPORTANT]
-> This project is **NOT** affiliated with, endorsed by, or connected to Microsoft Teams or Microsoft Corporation in any way. This is an independent tool for automated meeting recording.
+---
 
-## ⚙️ About The Project
-TeamsMeetingRecorder is a Docker-based bot that automates Teams meeting participation and audio recording. It uses browser automation to join meetings, processes audio through isolated [PulseAudio](https://de.wikipedia.org/wiki/PulseAudio) sinks, and provides a REST API for controlling recording sessions.
+> **Heads up:** not affiliated with, endorsed by, or connected to Microsoft in any way. And record responsibly — get explicit consent from every participant and check your local privacy law before you point this at a real meeting. See [Legal & privacy](#legal--privacy).
 
-## ✨ Features
-- **REST API**: Control bot via HTTP endpoints (FastAPI)
-- **Browser Automation**: Modern Playwright-based browser control
-- **Multi-Session Support**: Record multiple meetings simultaneously
-- **High-Quality Audio**: 48kHz stereo recording
-- **Automatic Participant Detection**: Leaves meeting when alone
-- **Flexible Storage**: Save recordings locally or to MinIO/S3-compatible storage
-- **Webhook Notifications**: Get notified when recordings complete (local or S3 upload)
-- **Docker Ready**: Fully containerized with Docker Compose
+## What is TeamsMeetingRecorder?
 
-## 🐳 Docker & Container Registry Usage
+A containerised bot that joins a Teams meeting as a guest and records what it hears. You POST a meeting link to the API, the bot joins through a real browser, waits out the lobby, records until the meeting empties, then hands the file to local disk, Azure Blob, or S3 and calls your webhook.
 
-### Option 1: Pull and Run a Pre-built Image
+Each session is fully isolated: its own browser and its own PulseAudio sink, so several meetings can be recorded at once without their audio mixing.
 
-**Docker Hub:**
-```bash
-docker pull pianonic/teamsmeetingrecorder:latest
-```
+## Features
 
-**GitHub Container Registry:**
-```bash
-docker pull ghcr.io/pianonic/teamsmeetingrecorder:latest
-```
+- **REST API** — start, stop, and inspect sessions over HTTP (FastAPI, with Swagger at `/docs`).
+- **Multi-session** — concurrent meetings each get a dedicated browser and audio sink, verified isolated end to end.
+- **Leaves on its own** — detects when the meeting has emptied and stops, uploads, and cleans up without being told.
+- **Flexible storage** — local disk, Azure Blob (or Azurite), or MinIO / any S3-compatible bucket.
+- **Webhooks** — POST on completion, optionally signed with a shared secret.
+- **Optional auth** — a bearer token in front of every endpoint except the health probe.
+- **48 kHz stereo** — recorded straight off a per-session virtual sink with `parec`.
 
-Then run:
+## Get started
+
+### Run the image
+
 ```bash
 docker run -d \
   -p 8000:8000 \
   -v ./recordings:/app/recordings \
   --shm-size=2gb \
+  --init \
   --name teams-recorder \
-  pianonic/teamsmeetingrecorder:latest
+  ghcr.io/pianonic/teamsmeetingrecorder:latest
 ```
 
-The API will be available at [http://localhost:8000](http://localhost:8000)
+Also on Docker Hub as `pianonic/teamsmeetingrecorder`. The API is then at [http://localhost:8000](http://localhost:8000), docs at [/docs](http://localhost:8000/docs).
 
-### Option 2: Run with Docker Compose (Recommended)
+### Docker Compose
 
-**1. Create a `compose.yaml` file:**
 ```yaml
 services:
   teams-recorder:
-    image: pianonic/teamsmeetingrecorder:latest
-    # image: ghcr.io/pianonic/teamsmeetingrecorder:latest
+    image: ghcr.io/pianonic/teamsmeetingrecorder:latest
     container_name: teams-meeting-recorder
     ports:
       - "8000:8000"
     volumes:
       - ./recordings:/app/recordings
     shm_size: '2gb'
+    init: true
     restart: unless-stopped
     environment:
       - TEAMS_WAIT_FOR_LOBBY=${TEAMS_WAIT_FOR_LOBBY:-30}
@@ -83,109 +80,86 @@ services:
       start_period: 40s
 ```
 
-**2. (Optional) Create a `.env` file for configuration:**
-```env
-TEAMS_WAIT_FOR_LOBBY=10
-STORAGE_BACKEND=local
-```
-
-**3. Start it:**
 ```bash
 docker compose up -d
 ```
 
-The API will be available at [http://localhost:8000](http://localhost:8000)
-Swagger docs at [http://localhost:8000/docs](http://localhost:8000/docs)
+> `--shm-size=2gb` keeps Chromium from crashing on `/dev/shm`. `--init` reaps the browser's child processes.
 
-## ⚙️ Configuration
+## Usage
 
-TeamsMeetingRecorder can be configured using environment variables. Create a `.env` file in your project directory or set them in your `compose.yaml`.
-
-### Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `TEAMS_WAIT_FOR_LOBBY` | `30` | Waiting room timeout in minutes before bot stops |
-| `STORAGE_BACKEND` | `local` | Storage backend: `local`, `minio`, or `azure` |
-| `MINIO_ENDPOINT` | - | MinIO server endpoint (e.g., `minio.example.com:9000`) |
-| `MINIO_ACCESS_KEY` | - | MinIO access key |
-| `MINIO_SECRET_KEY` | - | MinIO secret key |
-| `MINIO_BUCKET` | `recordings` | MinIO bucket name |
-| `MINIO_SECURE` | `true` | Use HTTPS for MinIO connection |
-| `AZURE_STORAGE_CONNECTION_STRING` | - | Azure / Azurite connection string (`STORAGE_BACKEND=azure`) |
-| `AZURE_STORAGE_CONTAINER` | `meeting-recordings` | Blob container name |
-| `AZURE_STORAGE_PUBLIC_ENDPOINT` | - | Optional public blob base URL for webhook `file_location` |
-| `WEBHOOK_URL` | - | Webhook URL to notify when recording completes (optional) |
-| `WEBHOOK_SECRET` | - | Optional shared secret sent as the `X-Webhook-Secret` header on webhook POSTs; the receiver verifies it against its `Webhook:Secret`. Unset = no signature. |
-| `BOT_ACCESS_TOKEN` | - | Optional shared secret protecting all endpoints except `/` (the health probe). When set, every request must send `Authorization: Bearer <token>` or `X-API-Key: <token>` (401 otherwise). Unset = open. |
-
-**Example `.env` file:**
-```env
-TEAMS_WAIT_FOR_LOBBY=10
-STORAGE_BACKEND=local
-WEBHOOK_URL=https://your-api.example.com/webhook
-```
-
-## 🚀 Usage
-
-### Join a Meeting
 ```bash
+# join a meeting and start recording
 curl -X POST http://localhost:8000/join \
   -H "Content-Type: application/json" \
-  -d '{
-    "meeting_url": "https://teams.microsoft.com/l/meetup-join/...",
-    "display_name": "Recording Bot"
-  }'
-```
+  -d '{"meeting_url": "https://teams.microsoft.com/l/meetup-join/...", "display_name": "Recording Bot"}'
 
-### Check Status
-```bash
+# check a session
 curl http://localhost:8000/status/{session_id}
-```
 
-### Stop Recording
-```bash
+# stop early (it stops on its own when the meeting empties)
 curl -X POST http://localhost:8000/stop/{session_id}
-```
 
-### List Active Sessions
-```bash
+# list running sessions
 curl http://localhost:8000/sessions
 ```
 
-## 🗄️ Storage Configuration
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/` | GET | Health probe and version. Never requires auth. |
+| `/join` | POST | Join a meeting and start recording. Returns a session id. |
+| `/status/{id}` | GET | Session state, uptime, and recording path. Answers after the session ends. |
+| `/stop/{id}` | POST | Stop a running session. |
+| `/sessions` | GET | List the sessions currently running. |
 
-TeamsMeetingRecorder supports three storage backends:
+## Configuration
 
-### Local Storage (Default)
-Recordings are saved to the local filesystem (`/app/recordings` in container, mounted as `./recordings` on host).
+Set these as environment variables or in a `.env` file.
 
-No additional configuration needed.
+| Variable | Default | Description |
+|---|---|---|
+| `TEAMS_WAIT_FOR_LOBBY` | `30` | Minutes to wait in the lobby before giving up |
+| `RECORDINGS_DIR` | `/app/recordings` | Where recordings are written before upload |
+| `MAX_RECORDING_MINUTES` | `240` | Hard cap on a single recording. Stops and uploads normally when hit. `0` disables the cap |
+| `STORAGE_BACKEND` | `local` | `local`, `azure`, or `minio` |
+| `WEBHOOK_URL` | – | Called when a recording finishes. Unset disables webhooks |
+| `WEBHOOK_SECRET` | – | Sent as `X-Webhook-Secret` for the receiver to verify. Unset sends no signature |
+| `BOT_ACCESS_TOKEN` | – | Protects every endpoint except `/`. Requires `Authorization: Bearer <token>` or `X-API-Key`. Unset leaves the API open |
+| `AZURE_STORAGE_CONNECTION_STRING` | – | Azure / Azurite connection string (`STORAGE_BACKEND=azure`) |
+| `AZURE_STORAGE_CONTAINER` | `meeting-recordings` | Blob container name |
+| `AZURE_STORAGE_PUBLIC_ENDPOINT` | – | Public blob base URL used in the webhook `file_location` |
+| `MINIO_ENDPOINT` | – | e.g. `minio.example.com:9000` (`STORAGE_BACKEND=minio`) |
+| `MINIO_ACCESS_KEY` | – | MinIO access key |
+| `MINIO_SECRET_KEY` | – | MinIO secret key |
+| `MINIO_BUCKET` | `recordings` | Bucket name |
+| `MINIO_SECURE` | `true` | Use HTTPS for MinIO |
 
-### Azure Blob Storage (Azurite)
-Store recordings in Azure Blob Storage or the [Azurite](https://github.com/Azure/Azurite) emulator.
+## Storage
 
-**Quick start with Azurite:**
-```bash
-docker compose -f azurite.compose.yaml up -d
-```
+Recordings land in `/app/recordings` first. With a remote backend they are uploaded once the meeting ends and the local copy is removed; the bucket is created if missing and files are keyed by session id.
 
-**`.env` example:**
+<details>
+<summary><strong>Azure Blob / Azurite</strong></summary>
+
 ```env
 STORAGE_BACKEND=azure
-AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:410000/devstoreaccount1;
+AZURE_STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true
 AZURE_STORAGE_CONTAINER=meeting-recordings
-WEBHOOK_URL=https://your-api.example.com/api/meetings/webhook/recording
 ```
 
-Webhook `file_location` is sent as `meeting-recordings/{session}/{file}.wav` (or a public HTTP URL when `AZURE_STORAGE_PUBLIC_ENDPOINT` is set). The receiver downloads via the same blob connection string.
+To bring up [Azurite](https://github.com/Azure/Azurite) alongside the recorder:
 
-### MinIO/S3 Storage
-Store recordings in MinIO or any S3-compatible object storage.
+```bash
+docker compose -f azurite.compose.yml up -d
+```
 
-#### Option 1: Use External MinIO/S3 Service
+`file_location` is sent as `meeting-recordings/{session}/{file}.wav`, or a full HTTP URL when `AZURE_STORAGE_PUBLIC_ENDPOINT` is set.
 
-**1. Create/Update `.env` file:**
+</details>
+
+<details>
+<summary><strong>MinIO / S3</strong></summary>
+
 ```env
 STORAGE_BACKEND=minio
 MINIO_ENDPOINT=minio.example.com:9000
@@ -195,133 +169,54 @@ MINIO_BUCKET=recordings
 MINIO_SECURE=true
 ```
 
-**2. Update `compose.yaml`:**
-```yaml
-services:
-  teams-recorder:
-    environment:
-      - TEAMS_WAIT_FOR_LOBBY=${TEAMS_WAIT_FOR_LOBBY:-30}
-      - STORAGE_BACKEND=${STORAGE_BACKEND:-local}
-      - WEBHOOK_URL=${WEBHOOK_URL:-}
-      - MINIO_ENDPOINT=${MINIO_ENDPOINT}
-      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
-      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
-      - MINIO_BUCKET=${MINIO_BUCKET:-recordings}
-      - MINIO_SECURE=${MINIO_SECURE:-true}
-    # Remove the recordings volume mount if not needed
-```
+To run MinIO locally alongside the recorder:
 
-#### Option 2: Run MinIO Locally (Recommended for Testing)
-
-Use the included `minio.compose.yml` to run MinIO alongside the recorder:
-
-**1. Create `.env` file:**
-```env
-TEAMS_WAIT_FOR_LOBBY=10
-STORAGE_BACKEND=minio
-MINIO_ENDPOINT=minio:9000
-MINIO_ACCESS_KEY=minioadmin
-MINIO_SECRET_KEY=minioadmin
-MINIO_BUCKET=recordings
-MINIO_SECURE=false
-```
-
-**2. Start both services:**
 ```bash
 docker compose -f minio.compose.yml up -d
 ```
 
-**Access:**
-- **MinIO Console**: [http://localhost:9001](http://localhost:9001)
-- **MinIO API**: [http://localhost:9000](http://localhost:9000)
-- **API**: [http://localhost:8000](http://localhost:8000)
+Console on [:9001](http://localhost:9001), API on [:9000](http://localhost:9000), recorder on [:8000](http://localhost:8000).
 
-Login to MinIO Console with the credentials from your `.env` file (default: `minioadmin` / `minioadmin`).
+</details>
 
-**Features:**
-- Automatic bucket creation if it doesn't exist
-- Recordings uploaded after meeting ends
-- Local temporary files cleaned up after successful upload
-- Files organized by session ID in MinIO
+## Webhooks
 
-## 🔔 Webhook Configuration
+Set `WEBHOOK_URL` and the bot POSTs JSON when a session ends — on success, and on failure with an empty `file_location`.
 
-TeamsMeetingRecorder can notify your application when a recording finishes (both for local and MinIO storage) by sending an HTTP POST request to a configured webhook URL.
-
-### Setup
-
-**1. Add webhook URL to `.env` file:**
-```env
-WEBHOOK_URL=https://your-api.example.com/webhook
-```
-
-**2. The webhook URL is automatically picked up from environment variables in `compose.yaml`**
-
-The webhook environment variable is already included in the Docker Compose examples above. Leave `WEBHOOK_URL` empty or unset to disable webhooks.
-
-### Webhook Payload
-
-When a recording completes or fails, the following JSON payload is sent to your webhook URL:
-
-**Example with MinIO storage:**
 ```json
 {
   "session_id": "550e8400-e29b-41d4-a716-446655440000",
   "meeting_url": "https://teams.microsoft.com/l/meetup-join/...",
-  "file_location": "https://minio.example.com:9000/recordings/550e8400-e29b-41d4-a716-446655440000/550e8400-e29b-41d4-a716-446655440000_20250121_143022.wav",
+  "file_location": "meeting-recordings/550e8400-.../550e8400-..._20250121_143022.wav",
   "started_at": "2025-01-21T14:30:22.123456",
   "stopped_at": "2025-01-21T14:35:45.654321"
 }
 ```
-
-**Example with local storage:**
-```json
-{
-  "session_id": "550e8400-e29b-41d4-a716-446655440000",
-  "meeting_url": "https://teams.microsoft.com/l/meetup-join/...",
-  "file_location": "/app/recordings/550e8400-e29b-41d4-a716-446655440000_20250121_143022.wav",
-  "started_at": "2025-01-21T14:30:22.123456",
-  "stopped_at": "2025-01-21T14:35:45.654321"
-}
-```
-
-### Webhook Details
-
-- **Timeout**: 30 seconds
-- **Method**: HTTP POST
-- **Content-Type**: `application/json`
-- **Success Status Codes**: 200, 201, 202, 204
-- **Fire-and-Forget**: Webhook sends in background without blocking recording completion
-- **Triggered On**:
-  - ✅ Recording completes successfully (local storage)
-  - ✅ Recording uploaded to MinIO/S3
-  - ✅ Recording fails (sent with empty `file_location`)
-
-### Field Descriptions
 
 | Field | Type | Description |
-|-------|------|-------------|
-| `session_id` | string | Unique identifier for the recording session (UUID) |
-| `meeting_url` | string | The Teams meeting URL that was joined |
-| `file_location` | string | Local file path (for local storage) or MinIO URL (for MinIO/S3 storage). Empty string if recording failed. |
-| `started_at` | ISO 8601 | When the bot started the session |
-| `stopped_at` | ISO 8601 | When the bot stopped the session |
+|---|---|---|
+| `session_id` | string | Session identifier (UUID) |
+| `meeting_url` | string | The meeting that was joined |
+| `file_location` | string | Local path, blob path, or object URL. Empty when the recording failed |
+| `started_at` | ISO 8601 | When the session started |
+| `stopped_at` | ISO 8601 | When the session stopped |
 
-## ⚠️ Legal & Privacy
+POST with a 30 second timeout; 200, 201, 202, and 204 count as delivered. A failed webhook is logged and does not fail the recording. Set `WEBHOOK_SECRET` to have it sent as the `X-Webhook-Secret` header.
 
-**IMPORTANT:** Always obtain consent before recording!
+## Legal & privacy
 
-- Get **explicit permission** from all meeting participants
-- Comply with local **privacy laws** (GDPR, CCPA, etc.)
-- Inform participants that recording is in progress
-- Do **not** expose this API publicly without authentication
-- Use only for **legitimate purposes** (documentation, compliance, etc.)
+Recording people has rules. Before you use this:
 
-## 📜 License
-This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+- Get **explicit consent** from every participant.
+- Comply with local **privacy law** — GDPR, CCPA, and friends.
+- Tell participants the meeting is being recorded.
+- Do **not** expose this API publicly without `BOT_ACCESS_TOKEN` set.
+- Use it for legitimate purposes only.
+
+## License
+
+See [LICENSE](LICENSE).
 
 ---
-<p align="center">Made with ❤️ by <a href="https://github.com/PianoNic">PianoNic</a></p>
-<p align="center">
-  <a href="https://buymeacoffee.com/pianonic"><img src="https://img.shields.io/badge/-buy_me_a%C2%A0coffee-gray?logo=buy-me-a-coffee" alt="Buy Me A Coffee"/></a>
-</p>
+
+<p align="center">Made with care by <a href="https://github.com/PianoNic">PianoNic</a></p>

--- a/app/bot.py
+++ b/app/bot.py
@@ -294,6 +294,17 @@ class TeamsBot:
         while self.status == BotStatus.RECORDING:
             polls += 1
 
+            # Hard cap, independent of anything the Teams UI tells us. Everything
+            # below reads the page, so a UI change could stop the bot ever leaving.
+            if settings.max_recording_minutes > 0 and self.started_at:
+                elapsed = (datetime.now() - self.started_at).total_seconds()
+                if elapsed >= settings.max_recording_minutes * 60:
+                    logger.warning(
+                        f"Reached max recording duration of {settings.max_recording_minutes} minutes, stopping"
+                    )
+                    await self.stop()
+                    break
+
             # Catches the meeting being ended for us, or the bot being removed.
             in_call = await self._still_in_meeting()
             if in_call is False:

--- a/app/config.py
+++ b/app/config.py
@@ -41,6 +41,11 @@ class Settings(BaseSettings):
     # override with RECORDINGS_DIR to run outside Docker.
     recordings_dir: str = "/app/recordings"
 
+    # Backstop on how long a single recording may run. Presence detection depends
+    # on Teams' UI, so if that ever stops firing the bot would otherwise record
+    # until the container restarts. Set to 0 to disable the cap.
+    max_recording_minutes: int = 240
+
     # Storage backend: 'local', 'minio', or 'azure'
     storage_backend: str = "local"
 
@@ -54,7 +59,7 @@ class Settings(BaseSettings):
     # Azure Blob settings (only used when storage_backend='azure')
     azure_storage_connection_string: Optional[str] = None
     azure_storage_container: str = "meeting-recordings"
-    # Optional public base for webhook file_location URLs (e.g. Azurite http://127.0.0.1:410000/devstoreaccount1)
+    # Optional public base for webhook file_location URLs (e.g. Azurite http://127.0.0.1:41000/devstoreaccount1)
     azure_storage_public_endpoint: Optional[str] = None
 
     # Webhook settings (optional)

--- a/azurite.compose.yml
+++ b/azurite.compose.yml
@@ -1,8 +1,8 @@
 # Azurite + TeamsMeetingRecorder with Azure Blob storage.
 # Usage:
-#   docker compose -f azurite.compose.yaml up -d
+#   docker compose -f azurite.compose.yml up -d
 #
-# Azurite blob API: http://localhost:410000
+# Azurite blob API: http://localhost:41000
 # Bot API: http://localhost:8000
 
 services:
@@ -11,7 +11,7 @@ services:
     container_name: teams-azurite
     command: azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --location /data
     ports:
-      - "410000:10000"
+      - "41000:10000"
     volumes:
       - azurite-data:/data
     networks:
@@ -24,11 +24,16 @@ services:
       - "8000:8000"
     environment:
       STORAGE_BACKEND: azure
+      # Azurite's published development account. Not a secret - it is the same
+      # fixed key on every Azurite install, and it only works against a local
+      # emulator. https://learn.microsoft.com/azure/storage/common/storage-use-azurite
       AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
       AZURE_STORAGE_CONTAINER: meeting-recordings
-      AZURE_STORAGE_PUBLIC_ENDPOINT: http://127.0.0.1:410000/devstoreaccount1
+      AZURE_STORAGE_PUBLIC_ENDPOINT: http://127.0.0.1:41000/devstoreaccount1
       WEBHOOK_URL: ${WEBHOOK_URL:-}
     shm_size: 2gb
+    # reap chromium's child processes; without an init they pile up as zombies
+    init: true
     depends_on:
       - azurite
     networks:

--- a/compose.yml
+++ b/compose.yml
@@ -10,6 +10,8 @@ services:
     volumes:
       - ./recordings:/app/recordings
     shm_size: '2gb'
+    # reap chromium's child processes; without an init they pile up as zombies
+    init: true
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/"]

--- a/minio.compose.yml
+++ b/minio.compose.yml
@@ -18,6 +18,8 @@ services:
       minio:
         condition: service_healthy
     shm_size: '2gb'
+    # reap chromium's child processes; without an init they pile up as zombies
+    init: true
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/"]


### PR DESCRIPTION
Three things, plus a few corrections found along the way.

## README

Restyled to match the layout used by the newer repos (KRINT, gaggaotaku): centred logo and tagline, badge row, `---`, `> **Heads up:**`, `## What is ...?`, bold lead-in feature bullets, then get-started. Emoji headings and the purple badge colour are gone.

Content corrections while rewriting:
- referenced `minio.compose.yml` — the file was `minio.compose.yaml`
- documented `DEBUG_SCREENSHOTS`, which no longer exists
- did not document `RECORDINGS_DIR`
- described webhooks as "fire-and-forget … without blocking", which was never true — the send is awaited with a 30s timeout
- Azurite endpoint used port `410000`, above the 65535 maximum

Every setting in `Settings` is now documented, and every documented variable exists.

## Compose files renamed to `.yml`

`compose.yaml`, `azurite.compose.yaml`, `minio.compose.yaml` → `.yml`, with all references updated.

## Azurite credentials

Docs no longer print the development account key; they use `UseDevelopmentStorage=true`. The literal key remains in `azurite.compose.yml`, where it must be — the recorder reaches Azurite over the compose network, and the shorthand resolves to `127.0.0.1` — now commented as the published emulator credential with a link, rather than looking like a leaked secret.

## Max recording duration — closes #40

`MAX_RECORDING_MINUTES`, default 240, `0` disables. Every existing way a recording ends reads the Teams UI, so a UI change could leave a session recording until the container restarts. This cap doesn't touch the page.

Verified both directions: with the cap exceeded the session stops without any page query (the page methods were stubbed to raise), and with `MAX_RECORDING_MINUTES=0` a 50-hour-old session keeps running.

## Reap browser children — closes #39

`init: true` in all three compose files, `--init` in the README's `docker run`.

Measured on two containers running the same session:

```
tmr-noinit  zombies=9
tmr-init    zombies=0
```
