### PR TITLE
Fix X11 restart, Azurite uploads, and the recording cap baseline

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -40,6 +40,7 @@ class TeamsBot:
 
         self.status = BotStatus.IDLE
         self.started_at: Optional[datetime] = None
+        self.recording_started_at: Optional[datetime] = None
         self.stopped_at: Optional[datetime] = None
         self.recording_file: Optional[str] = None
         self.storage_path: Optional[str] = None
@@ -296,8 +297,10 @@ class TeamsBot:
 
             # Hard cap, independent of anything the Teams UI tells us. Everything
             # below reads the page, so a UI change could stop the bot ever leaving.
-            if settings.max_recording_minutes > 0 and self.started_at:
-                elapsed = (datetime.now() - self.started_at).total_seconds()
+            # Measured from the start of the recording, not the start of the
+            # session - otherwise a long lobby wait eats into the cap.
+            if settings.max_recording_minutes > 0 and self.recording_started_at:
+                elapsed = (datetime.now() - self.recording_started_at).total_seconds()
                 if elapsed >= settings.max_recording_minutes * 60:
                     logger.warning(
                         f"Reached max recording duration of {settings.max_recording_minutes} minutes, stopping"
@@ -348,6 +351,7 @@ class TeamsBot:
             monitor_name=self.monitor_name
         )
         self.audio_recorder.start()
+        self.recording_started_at = datetime.now()
         self.status = BotStatus.RECORDING
         logger.info(f"Recording from '{self.monitor_name}' to: {self.recording_file}")
 

--- a/azurite.compose.yml
+++ b/azurite.compose.yml
@@ -9,7 +9,10 @@ services:
   azurite:
     image: mcr.microsoft.com/azure-storage/azurite
     container_name: teams-azurite
-    command: azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --location /data
+    # --skipApiVersionCheck: the azure-storage-blob SDK requests a newer service
+    # version than Azurite recognises, and without this every upload fails with
+    # InvalidHeaderValue "The API version ... is not supported by Azurite".
+    command: azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --location /data --skipApiVersionCheck
     ports:
       - "41000:10000"
     volumes:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,11 +38,25 @@ done
 echo "Available audio devices:"
 pactl list sinks short || echo "(PulseAudio reported no sinks)"
 
-# Start Xvfb
+# Start Xvfb. Its lock file and socket survive a restart exactly like PulseAudio's
+# runtime state, and a stale lock makes Xvfb refuse to start ("server already
+# running"). The container would still answer the health check while every
+# browser launch failed with "Missing X server or $DISPLAY", so clear them first.
 echo "Starting Xvfb on display :99..."
+rm -f /tmp/.X99-lock /tmp/.X11-unix/X99 2>/dev/null || true
 Xvfb :99 -screen 0 1280x720x24 -ac +extension GLX +render -noreset 2>/dev/null &
 XVFB_PID=$!
-sleep 2
+
+# Do not continue until the display actually accepts connections.
+for _ in $(seq 1 15); do
+    xset -q -display :99 >/dev/null 2>&1 && break
+    sleep 1
+done
+if ! xset -q -display :99 >/dev/null 2>&1; then
+    echo "FATAL: Xvfb did not come up on :99 - a browser could never launch." >&2
+    exit 1
+fi
+echo "Xvfb is up on :99"
 
 # Start window manager
 echo "Starting Fluxbox window manager..."


### PR DESCRIPTION
Found by running three concurrent meetings end to end with real audio, against Azure storage and a webhook receiver — the configuration production actually uses, which had never been exercised.

## Xvfb lock survives a restart — closes #44

Same class as #41, worse symptom. `/tmp/.X99-lock` persisted, Xvfb refused to start, and nothing checked:

```
GET /                    -> 200, healthcheck green
POST /join               -> error in 0.4s
  Missing X server or $DISPLAY
```

A restarted container accepted meetings and dropped every one of them while reporting healthy. Now the lock and socket are cleared, the entrypoint waits for the display, and exits loudly if it never comes up.

## Azurite rejects every upload — closes #45

`azurite.compose.yml` was missing `--skipApiVersionCheck`, so `azure-storage-blob==12.29.0` requested a service version Azurite 3.35.0 rejects:

```
The API version 2026-04-06 is not supported by Azurite
ErrorCode:InvalidHeaderValue
```

All three sessions hit `status: error` and uploaded nothing. The documented local-dev path could never have worked.

## Recording cap baseline

`MAX_RECORDING_MINUTES` measured from session start, so a 30-minute lobby wait silently reduced a 240-minute cap to 210. Now measured from the start of the recording.

## Verified after the fixes

Three meetings recorded simultaneously, each with a different section of the same track injected:

- three sessions, each with its own sink and its own chromium (`/proc/<pid>/environ`)
- all three uploaded to Azure Blob, local copies removed
- 9 webhooks delivered, `X-Webhook-Secret` present on every one; the three failed sessions correctly sent an empty `file_location`
- `/sessions` empty afterwards, `/status` still answering, all sinks unloaded
- recordings mutually uncorrelated (max 0.107, against 1.000 for identical material) — no sign of cross-talk

One limit worth recording: matching a recording against the clean source audio does **not** work. Teams band-limits to roughly 2 kHz and its noise suppression removes music (spectral centroid 4300 Hz → 1800 Hz; 5–35% of frames gated to silence). Attribution of a specific segment to a specific file has to be done by ear.
