### PR TITLE
Give a declined bot its own status

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ curl http://localhost:8000/sessions
 | `/stop/{id}` | POST | Stop a running session. |
 | `/sessions` | GET | List the sessions currently running. |
 
+### Session status
+
+`/status/{id}` reports one of these. The failure cases are distinct on purpose, so a caller can act on them without matching on `error_message`.
+
+| Status | Meaning |
+|---|---|
+| `joining` | Requested to join, waiting in the lobby |
+| `recording` | In the meeting and recording |
+| `denied` | An organiser declined the bot from the lobby. It will not get in; retrying needs someone to let it through |
+| `error` | Something went wrong — never admitted within the timeout, a browser or storage failure. See `error_message` |
+| `stopped` | Finished normally. The recording is at `recording_file` or already uploaded |
+
 ## Configuration
 
 Set these as environment variables or in a `.env` file.

--- a/app/bot.py
+++ b/app/bot.py
@@ -19,6 +19,10 @@ from app.webhook import send_webhook, WebhookPayload
 logger = logging.getLogger(__name__)
 
 
+class MeetingDenied(RuntimeError):
+    """An organiser declined the bot from the lobby."""
+
+
 class TeamsBot:
     """Bot that joins Teams meetings and records audio using Playwright."""
 
@@ -215,7 +219,7 @@ class TeamsBot:
             was_denied = False
 
         if was_denied:
-            raise RuntimeError("Denied entry to the meeting")
+            raise MeetingDenied("Denied entry to the meeting")
 
         logger.info("Joined meeting")
 
@@ -389,7 +393,8 @@ class TeamsBot:
 
         except Exception as e:
             logger.error(f"Start failed: {e}")
-            self.status = BotStatus.ERROR
+            # Being turned away is a distinct outcome, not a malfunction.
+            self.status = BotStatus.DENIED if isinstance(e, MeetingDenied) else BotStatus.ERROR
             self.error_message = str(e)
             self.stopped_at = datetime.now()
 
@@ -500,7 +505,7 @@ class TeamsBot:
             except Exception as e:
                 logger.error(f"Error removing audio sink: {e}")
 
-        if self.status != BotStatus.ERROR:
+        if self.status not in (BotStatus.ERROR, BotStatus.DENIED):
             self.status = BotStatus.STOPPED
         logger.info(f"Cleanup complete for {self.session_id}")
 

--- a/app/models.py
+++ b/app/models.py
@@ -12,6 +12,10 @@ class BotStatus(str, Enum):
     JOINING = "joining"
     RECORDING = "recording"
     LEAVING = "leaving"
+    # An organiser actively declined the bot from the lobby. Distinct from ERROR
+    # so callers can tell "we were turned away" from "something broke", without
+    # matching on the text of error_message.
+    DENIED = "denied"
     ERROR = "error"
     STOPPED = "stopped"
 


### PR DESCRIPTION
Follow-up to #48. Denial was reported as `error`, with the actual reason only in `error_message` — so distinguishing "an organiser said no" from "the browser fell over" meant string-matching a log message.

## Change

- `BotStatus.DENIED` (`"denied"`) added to the enum
- `MeetingDenied` exception, so `start()` classifies by type rather than by message text:
  ```python
  self.status = BotStatus.DENIED if isinstance(e, MeetingDenied) else BotStatus.ERROR
  ```
- `cleanup()` used to stamp `STOPPED` over anything that was not `ERROR`, which would have erased the new state — it now preserves both terminal failure states
- Status values documented in the README; they are part of the API surface and were written down nowhere

## Verified against a real meeting

```json
{
  "status": "denied",
  "recording_file": null,
  "error_message": "Denied entry to the meeting"
}
```

Reported ~5 s after the organiser declined, unchanged after cleanup, sink released, session retired.

## Note on the sibling case

A lobby timeout — nobody accepted or declined — still reports `error`. The three outcomes call for different reactions (`denied`: don't retry, tell a human; timeout: maybe retry later; `error`: technical, alert ops), so a `not_admitted` value would be defensible too. Left out because it wasn't asked for; happy to add it as a one-liner.
