### PR TITLE
Separate "nobody answered" from other failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ curl http://localhost:8000/sessions
 | `joining` | Requested to join, waiting in the lobby |
 | `recording` | In the meeting and recording |
 | `denied` | An organiser declined the bot from the lobby. It will not get in; retrying needs someone to let it through |
-| `error` | Something went wrong — never admitted within the timeout, a browser or storage failure. See `error_message` |
+| `not_admitted` | Nobody accepted or declined the bot before `TEAMS_WAIT_FOR_LOBBY` ran out. Worth retrying later |
+| `error` | Something went wrong — a browser, audio or storage failure. See `error_message` |
 | `stopped` | Finished normally. The recording is at `recording_file` or already uploaded |
 
 ## Configuration

--- a/app/bot.py
+++ b/app/bot.py
@@ -23,6 +23,10 @@ class MeetingDenied(RuntimeError):
     """An organiser declined the bot from the lobby."""
 
 
+class NotAdmitted(RuntimeError):
+    """Nobody accepted or declined the bot before the lobby timeout."""
+
+
 class TeamsBot:
     """Bot that joins Teams meetings and records audio using Playwright."""
 
@@ -208,7 +212,7 @@ class TeamsBot:
         try:
             await hangup.or_(denied).first.wait_for(state="visible", timeout=timeout_ms)
         except Exception:
-            raise RuntimeError(
+            raise NotAdmitted(
                 f"Never admitted: nobody accepted or declined the bot within "
                 f"{settings.teams_wait_for_lobby} minutes"
             )
@@ -269,6 +273,10 @@ class TeamsBot:
     # Anonymous joins usually land in Teams' "light meetings" client, which has no
     # participant badge at all - it shows this instead while the bot is the only
     # one left. The bot forces Accept-Language en-US, so the string is stable.
+    # States that mean the session failed. cleanup() must not stamp STOPPED
+    # over any of them.
+    TERMINAL_FAILURES = (BotStatus.DENIED, BotStatus.NOT_ADMITTED, BotStatus.ERROR)
+
     ALONE_TEXT = "Waiting for others to join"
 
     # Shown on the bot's own page when an organiser declines it from the lobby.
@@ -393,8 +401,14 @@ class TeamsBot:
 
         except Exception as e:
             logger.error(f"Start failed: {e}")
-            # Being turned away is a distinct outcome, not a malfunction.
-            self.status = BotStatus.DENIED if isinstance(e, MeetingDenied) else BotStatus.ERROR
+            # Not getting in is a distinct outcome, not a malfunction, and being
+            # refused is not the same as being ignored.
+            if isinstance(e, MeetingDenied):
+                self.status = BotStatus.DENIED
+            elif isinstance(e, NotAdmitted):
+                self.status = BotStatus.NOT_ADMITTED
+            else:
+                self.status = BotStatus.ERROR
             self.error_message = str(e)
             self.stopped_at = datetime.now()
 
@@ -505,7 +519,7 @@ class TeamsBot:
             except Exception as e:
                 logger.error(f"Error removing audio sink: {e}")
 
-        if self.status not in (BotStatus.ERROR, BotStatus.DENIED):
+        if self.status not in self.TERMINAL_FAILURES:
             self.status = BotStatus.STOPPED
         logger.info(f"Cleanup complete for {self.session_id}")
 

--- a/app/models.py
+++ b/app/models.py
@@ -12,10 +12,12 @@ class BotStatus(str, Enum):
     JOINING = "joining"
     RECORDING = "recording"
     LEAVING = "leaving"
-    # An organiser actively declined the bot from the lobby. Distinct from ERROR
-    # so callers can tell "we were turned away" from "something broke", without
-    # matching on the text of error_message.
+    # The two ways of not getting in, kept apart from ERROR and from each other:
+    # they call for different reactions. DENIED means someone said no, so
+    # retrying is pointless without a human. NOT_ADMITTED means nobody answered
+    # at all, which is worth retrying later.
     DENIED = "denied"
+    NOT_ADMITTED = "not_admitted"
     ERROR = "error"
     STOPPED = "stopped"
 


### PR DESCRIPTION
Completes #49. A lobby timeout still came back as `error`, alongside browser and storage faults, so a caller could not tell "nobody was there" from "something is broken".

The three outcomes want different reactions:

| Status | What a caller should do |
|---|---|
| `denied` | Someone said no. Retrying is pointless without a human. |
| `not_admitted` | Nobody answered. A later attempt may well work. |
| `error` | Technical fault. Alert whoever runs it. |

## Change

- `BotStatus.NOT_ADMITTED` and a `NotAdmitted` exception, mirroring `MeetingDenied`
- `TeamsBot.TERMINAL_FAILURES` collects the failure states so `cleanup()` checks one list instead of a tuple that grows inline each time — that guard already came close to erasing `denied` in #49

## Verified against a real meeting

Both paths, same meeting, one after the other:

```
status=not_admitted   msg=Never admitted: nobody accepted or declined the bot within 2 minutes
status=denied         msg=Denied entry to the meeting
```

Denial detected ~5 s after the click; the timeout case fired at its deadline. Both sent the failure webhook with an empty `file_location`, released the audio sink and retired the session.

README status table updated.
